### PR TITLE
Preview.setTime() can accept string input from element.time property

### DIFF
--- a/src/Preview.ts
+++ b/src/Preview.ts
@@ -371,13 +371,16 @@ export class Preview {
   }
 
   /**
-   * Seeks to the provided playback time.
+   * Seeks to the provided playback time. If provided as a string from time property on element, regex will extract 
+   * the value accordingly.
    *
    * @param time Playback time in seconds.
    * @see onTimeChange()
    */
-  async setTime(time: number): Promise<void> {
-    return this._sendCommand({ message: 'setTime', time }).catch((error) => {
+  async setTime(time: number | string): Promise<void> {
+    const reg = /(\d+(\.\d+)?)\s*s/
+    const timeValue = reg.exec(time.toString())
+    return this._sendCommand({ message: 'setTime', timeValue }).catch((error) => {
       throw new Error(`Failed to set time: ${error.message}`);
     });
   }

--- a/src/Preview.ts
+++ b/src/Preview.ts
@@ -379,7 +379,8 @@ export class Preview {
    */
   async setTime(time: number | string): Promise<void> {
     const reg = /(\d+(\.\d+)?)\s*s/
-    const timeValue = reg.exec(time.toString())
+    const regArray = reg.exec(time.toString()) || []
+    const timeValue = regArray[0] 
     return this._sendCommand({ message: 'setTime', timeValue }).catch((error) => {
       throw new Error(`Failed to set time: ${error.message}`);
     });

--- a/src/Preview.ts
+++ b/src/Preview.ts
@@ -380,7 +380,7 @@ export class Preview {
   async setTime(time: number | string): Promise<void> {
     const reg = /(\d+(\.\d+)?)\s*s/
     const regArray = reg.exec(time.toString()) || []
-    const timeValue = regArray[0] 
+    const timeValue = Number(regArray[1])
     return this._sendCommand({ message: 'setTime', timeValue }).catch((error) => {
       throw new Error(`Failed to set time: ${error.message}`);
     });


### PR DESCRIPTION
Updated the setTime method on the Preview class to accept a string input. The intention is to take the time property of each element and use that as the input for setTime.

Currently, I am using this approach and seemed to me like it would be useful as part of the library. 

Happy to add tests but couldn't find a testing folder. 